### PR TITLE
modify gitignore

### DIFF
--- a/.Dockerignore
+++ b/.Dockerignore
@@ -1,0 +1,7 @@
+.next
+node_modules
+1postman_collection.json
+2swagger_collection.json
+package-lock.json
+connect-psql.sh
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Ignore all .DS_Store files recursively
-.DS_Store
+**/.DS_Store
 node_modules/
 .next
+utils/data/


### PR DESCRIPTION
This pull request includes changes to the `.Dockerignore` file to improve the Docker build process by excluding unnecessary files and directories.

* [`.Dockerignore`](diffhunk://#diff-5b76345842b277a22a71d09b578c8329cba10c9ba39917fd88c26c965fe961acR1-R7): Added several files and directories to be ignored by Docker, including `.next`, `node_modules`, `postman_collection.json`, `swagger_collection.json`, `package-lock.json`, `connect-psql.sh`, and `README.md`.